### PR TITLE
Removed obsolete text properties

### DIFF
--- a/src/elements/headings/_paragraph.scss
+++ b/src/elements/headings/_paragraph.scss
@@ -52,8 +52,6 @@
 
   &-card {
     @include font(16, 16);
-    line-height: 1.2;
-    font-weight: 400;
   }
 }
 


### PR DESCRIPTION
The `line-height` was wrong, the `font-weight` redundant.

