### PR TITLE
fix: page index

### DIFF
--- a/src/handlebars-json/vantaggi-economici.json
+++ b/src/handlebars-json/vantaggi-economici.json
@@ -717,10 +717,6 @@
         {
           "item": "Servizi correlati",
           "anchor": "related-service"
-        },
-        {
-          "item": "Valuta il servizio",
-          "anchor": "rating"
         }
       ],
       "related-services": [


### PR DESCRIPTION
Removed anchor link to evaluation section, as it doesn't belong to main content.