### PR TITLE
fix: links display

### DIFF
--- a/src/stylesheets/base/_reset.scss
+++ b/src/stylesheets/base/_reset.scss
@@ -6,7 +6,6 @@
 
 a {
   cursor: pointer;
-  display: inline-block;
 }
 
 a,


### PR DESCRIPTION
Rimossa la dichiarazione `display: inline-block` dal file CSS di reset, applicata a tutto i tag `<a>`